### PR TITLE
Restrict Sass file loading to theme subdir of design

### DIFF
--- a/src/config/design.js
+++ b/src/config/design.js
@@ -16,6 +16,22 @@ const { current } = require.main.require('./src/config/current')
 //
 
 if (fs.existsSync(config.file.project) && fs.existsSync(config.file.design)) {
+  // Set theme dir
+  if (config.design.dirs.theme && config.design.dirs.theme.dir) {
+    config.design.theme = path.join(
+      config.current.design.path,
+      config.design.dirs.theme.dir
+    )
+  } else {
+    config.design.theme = path.join(
+      config.current.design.path,
+      config.project.dirs.design.theme.dir
+    )
+  }
+  // Theme dir is always loaded from the design, even if the current path is
+  // for an email.
+  config.current.design.theme = config.design.theme
+
   // Prepare internal-only (not included in config file) design settings.
   if (config.design.fonts) {
     // Font stack

--- a/src/example/premail.yaml
+++ b/src/example/premail.yaml
@@ -1,7 +1,7 @@
 #
 # PREMAIL CONFIGURATION
 #
-# This file is formatted in YAML -- indentation and whitespace is important!
+# This file is formatted in YAML -- indentation and spaces are important!
 #
 # If you're not familiar with YAML, there are lots of guides and many
 # implementations out there. Here are some examples:

--- a/src/example/premail.yaml
+++ b/src/example/premail.yaml
@@ -29,9 +29,9 @@ dirs:
     # If no design is specified when building, default to this design
     default: _default
 
-  theme:
-    # Subdirectory of each design where styles are kept
-    dir: theme
+    theme:
+      # Subdirectory of each design where styles are kept
+      dir: theme
 
   email:
     # Name of the parent directory containing each individual email

--- a/src/settings/init.yaml
+++ b/src/settings/init.yaml
@@ -5,8 +5,8 @@ dirs:
   design:
     name: designs
     default: _default
-  theme:
-    dir: theme
+    theme:
+      dir: theme
   email:
     name: emails
   output:

--- a/src/tasks/build.js
+++ b/src/tasks/build.js
@@ -50,7 +50,7 @@ const built = {
 //
 function styles () {
   // Set styles source
-  const sourceStyles = config.current.design.path + '/**/*.scss'
+  const sourceStyles = config.current.design.theme + '/**/*.scss'
 
   return pipeline(
     src(sourceStyles),

--- a/src/tasks/watchEmail.js
+++ b/src/tasks/watchEmail.js
@@ -21,7 +21,7 @@ module.exports = function watchEmail (done) {
   const paths = {
     configProject: config.file.project,
     configDesign: config.current.design.path + path.sep + config.file.design,
-    style: config.current.design.path + '/**/*.scss',
+    style: config.current.design.theme + '/**/*.scss',
     template: config.current.path + '/**/*.' + config.design.templates.ext,
     partials: config.current.path + '/**/*.mjml',
     html: config.current.path + '/**/*.html',


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type. Submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

`build` and `watch` processes load Sass from anywhere in the design directory.

This was revealed when I went to change the `theme` config object and realized it wasn't actually being called anywhere.

Issue Number(s): #64 

## What is the new behavior?

Properly `build` and `watch` should only load Sass files from the designated `theme` subdirectory.

This is only minimally a feature, but might theoretically slightly increase build time.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

Documentation indicates that Sass should be placed in the `theme` subdir. This change just enforces that instruction, but also makes the name of that subdir actually configurable.

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
