### PR TITLE
Move colored console output from ansi-colors to kleur

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1436,32 +1436,6 @@
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
       "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA=="
     },
-    "ansi-colors-nestable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-colors-nestable/-/ansi-colors-nestable-0.1.1.tgz",
-      "integrity": "sha1-bqduFckPC+6/+PYfCe1192IvTHo=",
-      "requires": {
-        "ansi-colors": "^1.0.1"
-      },
-      "dependencies": {
-        "ansi-colors": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
-          "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
-          "requires": {
-            "ansi-wrap": "^0.1.0"
-          }
-        }
-      }
-    },
-    "ansi-colors-prioritized": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ansi-colors-prioritized/-/ansi-colors-prioritized-0.1.2.tgz",
-      "integrity": "sha512-1Jbo0/nc50brWZd8AuuQbnK0zKDerDnsyRkbqyDLkGQmC66T9cJgHxyjP6Mwpji3SkiR2Ylivm784ZAqkuJ4Hw==",
-      "requires": {
-        "ansi-colors-nestable": "^0.1.0"
-      }
-    },
     "ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -5336,6 +5310,11 @@
         "unc-path-regex": "^0.1.2"
       }
     },
+    "is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="
+    },
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
@@ -6393,9 +6372,9 @@
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
     },
     "kleur": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
+      "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA=="
     },
     "language-subtag-registry": {
       "version": "0.3.21",
@@ -6607,11 +6586,12 @@
       "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw="
     },
     "log-symbols": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
-      "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
       "requires": {
-        "chalk": "^4.0.0"
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
       }
     },
     "loose-envify": {
@@ -7855,6 +7835,14 @@
           "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
           "requires": {
             "argparse": "^2.0.1"
+          }
+        },
+        "log-symbols": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+          "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+          "requires": {
+            "chalk": "^4.0.0"
           }
         },
         "ms": {
@@ -11898,6 +11886,13 @@
       "requires": {
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.5"
+      },
+      "dependencies": {
+        "kleur": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+          "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
+        }
       }
     },
     "prop-types": {

--- a/package.json
+++ b/package.json
@@ -52,8 +52,6 @@
     "url": "https://github.com/sponsors/rootwork"
   },
   "dependencies": {
-    "ansi-colors": "^4.1.1",
-    "ansi-colors-prioritized": "^0.1.2",
     "del": "^6.0.0",
     "detergent": "^7.1.0",
     "fibers": "^5.0.1",
@@ -69,6 +67,8 @@
     "html-img-alt": "^2.1.0",
     "html-to-text": "^8.1.0",
     "js-yaml": "^4.1.0",
+    "kleur": "^4.1.4",
+    "log-symbols": "^4.1.0",
     "map-stream": "0.0.7",
     "mjml": "^4.12.0",
     "mjml-bullet-list": "^1.2.2",

--- a/src/ops/errors.js
+++ b/src/ops/errors.js
@@ -11,7 +11,7 @@ const notify = require.main.require('./src/ops/notifications')
 // General error-handling function.
 // @TODO: Incorporate other error types into this one, accommodating
 // .on('error')
-function e (err, type = null, subtype = null) {
+function e(err, type = null, subtype = null) {
   const error = err.message
 
   switch (type) {
@@ -20,9 +20,7 @@ function e (err, type = null, subtype = null) {
       if (error.includes('design.js') && error.includes('Error: expected')) {
         return notify.msg(
           'warn',
-          'Sass variable import choked on the design configuration. Did you make sure to double quote anything with CSS-reserved selectors like URLs?' +
-            notify.colors.bold(` "'https://example.com/'" `) +
-            'See the "SYNTAX NOTES" section at the top of your designConfig.yaml file.',
+          `Sass variable import choked on the design configuration. Did you make sure to double quote anything with CSS-reserved selectors like URLs?'\n"'https://example.com/'"\nSee the "SYNTAX NOTES" section at the top of your designConfig.yaml file.`,
           'Sass processing error:'
         )
       } else {
@@ -41,7 +39,7 @@ function e (err, type = null, subtype = null) {
 }
 
 // Handlebars
-const hbError = function logError (error) {
+const hbError = function logError(error) {
   const message = new PluginError('gulp-hb', error.message).toString()
   notify.msg('error', `${message}`, 'Handlebars processing error:')
   notify.msg('error', '', 'Templates were not created!')
@@ -49,7 +47,7 @@ const hbError = function logError (error) {
 }
 
 // MJML
-const mjmlError = function logError (error) {
+const mjmlError = function logError(error) {
   const message = new PluginError('gulp-mjml', error.message).toString()
   notify.msg('error', `${message}`, 'MJML processing error:')
   notify.msg('error', '', 'HTML was not built!')
@@ -57,7 +55,7 @@ const mjmlError = function logError (error) {
 }
 
 // Plain text
-const textError = function logError (error) {
+const textError = function logError(error) {
   const message = new PluginError('gulp-html2txt', error.message).toString()
   notify.msg('error', `${message}`, 'Plain-text generation error:')
   notify.msg('error', '', 'Plain text version was not built!')

--- a/src/ops/notifications.js
+++ b/src/ops/notifications.js
@@ -47,9 +47,9 @@ function msg(type, message, title = null) {
       symbolFormat = '\n ' + symbols.error
       if (title) {
         titleFormat = console.error(
-          ` ${symbolFormat} ` + bgRed(white(bold(' ' + title + ' '))) + ' '
+          ` ${symbolFormat} ` + bgRed(white(bold(` ${title} `))) + ' '
         )
-        messageFormat = console.error(red('    ' + message))
+        messageFormat = console.error(red(`    ${message}`))
       } else {
         titleFormat = null
         messageFormat = console.error(
@@ -61,9 +61,9 @@ function msg(type, message, title = null) {
       symbolFormat = '\n ' + symbols.warning
       if (title) {
         titleFormat = console.warn(
-          inverse(yellow(bold(` ${symbolFormat} ` + title + ' ')))
+          inverse(yellow(bold(` ${symbolFormat} ${title} `)))
         )
-        messageFormat = console.warn(yellow('   ' + message))
+        messageFormat = console.warn(yellow(`   ${message}`))
       } else {
         titleFormat = null
         messageFormat = console.warn(
@@ -75,7 +75,7 @@ function msg(type, message, title = null) {
       symbolFormat = '\n ' + symbols.success
       if (title) {
         titleFormat = console.log(` ${symbolFormat} ` + green(bold(title)))
-        messageFormat = console.log(green('   ' + message))
+        messageFormat = console.log(green(`   ${message}`))
       } else {
         titleFormat = null
         messageFormat = console.log(
@@ -87,7 +87,7 @@ function msg(type, message, title = null) {
       symbolFormat = '\n ' + symbols.info
       if (title) {
         titleFormat = console.log(` ${symbolFormat} ` + cyan(bold(title)))
-        messageFormat = console.log(cyan('   ' + message))
+        messageFormat = console.log(cyan(`   ${message}`))
       } else {
         titleFormat = null
         messageFormat = console.log(` ${symbolFormat} ` + cyan(message) + ' \n')
@@ -98,7 +98,7 @@ function msg(type, message, title = null) {
         symbolFormat = '\n ' + symbols.info
         if (title) {
           titleFormat = console.log(` ${symbolFormat} ` + cyan(bold(title)))
-          messageFormat = console.log(cyan('   ' + message))
+          messageFormat = console.log(cyan(`   ${message}`))
         } else {
           titleFormat = null
           messageFormat = console.log(
@@ -129,7 +129,7 @@ function msg(type, message, title = null) {
             '"\x1b[0m\n'
         )
       } else {
-        console.error('\x1b[31mSupplied value was: "' + type + '"\x1b[0m\n')
+        console.error(`\x1b[31mSupplied value was: "${type}"\x1b[0m\n`)
       }
   }
 
@@ -145,7 +145,7 @@ function watch(message) {
 function json(object, title = null) {
   let objectFormatted = '\n '
   if (title) {
-    objectFormatted += symbols.info + ' ' + bold(title) + ' \n'
+    objectFormatted += `${symbols.info} ` + bold(title) + ' \n'
   }
   objectFormatted +=
     '\n ' + console.dir(object, { depth: null, colors: true }) + ' \n'
@@ -155,7 +155,7 @@ function json(object, title = null) {
 function unjson(object, title = null) {
   let objectFormatted = '\n '
   if (title) {
-    objectFormatted += symbols.info + ' ' + bold(title) + ' \n'
+    objectFormatted += `${symbols.info} ` + bold(title) + ' \n'
   }
   const objectFlattened = JSON.stringify(object, null, 2)
 

--- a/src/ops/notifications.js
+++ b/src/ops/notifications.js
@@ -2,20 +2,27 @@
 
 /* eslint-disable no-unused-vars */
 const path = require('path')
-const colors = require('ansi-colors')
-const prioritizedColor = require('ansi-colors-prioritized')
+const symbols = require('log-symbols')
+const {
+  green,
+  yellow,
+  red,
+  cyan,
+  white,
+  bgRed,
+  bold,
+  inverse,
+} = require('kleur/colors')
+
+// const colors = require('ansi-colors')
+// const prioritizedColor = require('ansi-colors-prioritized')
+
 const flags = require('yargs').argv
 /* eslint-enable no-unused-vars */
 
 //
 // Set notifications
 //
-
-// Set message styles
-const { symbols } = colors
-
-// Provide fallback colors for 'bright' versions
-const greenBright = prioritizedColor(colors.greenBright, colors.green)
 
 // Format messages
 function msg(type, message, title = null) {
@@ -37,16 +44,16 @@ function msg(type, message, title = null) {
   // Theme notification types
   switch (type) {
     case 'error':
-      symbolFormat = '\n ' + symbols.cross
+      symbolFormat = '\n ' + symbols.error
       if (title) {
         titleFormat = console.error(
-          ' ' + colors.bgRed.white.bold(symbolFormat + ' ' + title + ' ') + ' '
+          ` ${symbolFormat} ` + bgRed(white(bold(' ' + title + ' '))) + ' '
         )
-        messageFormat = console.error(colors.red('   ' + message))
+        messageFormat = console.error(red('    ' + message))
       } else {
         titleFormat = null
         messageFormat = console.error(
-          ' ' + colors.red.bold(symbolFormat + ' ' + message) + ' \n'
+          ` ${symbolFormat} ` + red(bold(message)) + ' \n'
         )
       }
       break
@@ -54,58 +61,48 @@ function msg(type, message, title = null) {
       symbolFormat = '\n ' + symbols.warning
       if (title) {
         titleFormat = console.warn(
-          ' ' +
-            colors.bgYellow.black.bold(symbolFormat + ' ' + title + ' ') +
-            ' '
+          inverse(yellow(bold(` ${symbolFormat} ` + title + ' ')))
         )
-        messageFormat = console.warn(colors.yellow('   ' + message))
+        messageFormat = console.warn(yellow('   ' + message))
       } else {
         titleFormat = null
         messageFormat = console.warn(
-          ' ' + colors.bgYellow.black(symbolFormat + ' ' + message) + ' \n'
+          ` ${symbolFormat} ` + yellow(bold(message)) + ' \n'
         )
       }
       break
     case 'success':
-      symbolFormat = '\n ' + symbols.check
+      symbolFormat = '\n ' + symbols.success
       if (title) {
-        titleFormat = console.log(
-          ' ' + colors.bold(greenBright(symbolFormat + ' ' + title + ' ')) + ' '
-        )
-        messageFormat = console.log(greenBright('   ' + message))
+        titleFormat = console.log(` ${symbolFormat} ` + green(bold(title)))
+        messageFormat = console.log(green('   ' + message))
       } else {
         titleFormat = null
         messageFormat = console.log(
-          ' ' + greenBright(symbolFormat + ' ' + message) + ' \n'
+          ` ${symbolFormat} ` + green(message) + ' \n'
         )
       }
       break
     case 'info':
       symbolFormat = '\n ' + symbols.info
       if (title) {
-        titleFormat = console.log(
-          ' ' + colors.cyan.bold(symbolFormat + ' ' + title + ' ') + ' '
-        )
-        messageFormat = console.log(colors.cyan('   ' + message))
+        titleFormat = console.log(` ${symbolFormat} ` + cyan(bold(title)))
+        messageFormat = console.log(cyan('   ' + message))
       } else {
         titleFormat = null
-        messageFormat = console.log(
-          ' ' + colors.cyan(symbolFormat + ' ' + message) + ' \n'
-        )
+        messageFormat = console.log(` ${symbolFormat} ` + cyan(message) + ' \n')
       }
       break
     case 'debug':
       if (flags.debug) {
         symbolFormat = '\n ' + symbols.info
         if (title) {
-          titleFormat = console.log(
-            ' ' + colors.cyan.bold(symbolFormat + ' ' + title + ' ') + ' '
-          )
-          messageFormat = console.log(colors.cyan('   ' + message))
+          titleFormat = console.log(` ${symbolFormat} ` + cyan(bold(title)))
+          messageFormat = console.log(cyan('   ' + message))
         } else {
           titleFormat = null
           messageFormat = console.log(
-            ' ' + colors.cyan.bold(symbolFormat + ' ' + message) + ' \n'
+            ` ${symbolFormat} ` + cyan(bold(message)) + ' \n'
           )
         }
       } else {
@@ -114,11 +111,11 @@ function msg(type, message, title = null) {
       break
     case 'plain':
       if (title) {
-        titleFormat = console.log(colors.white.bold(title))
-        messageFormat = console.log(colors.white(message))
+        titleFormat = console.log(white(bold(title)))
+        messageFormat = console.log(white(message))
       } else {
         titleFormat = null
-        messageFormat = console.log(colors.white(message))
+        messageFormat = console.log(white(message))
       }
       break
     default:
@@ -141,16 +138,14 @@ function msg(type, message, title = null) {
 
 function watch(message) {
   return console.log(
-    '\n ⌚ ' +
-      colors.bgGreen.black.bold(' ' + message.toUpperCase() + ' ') +
-      ' ⌚\n'
+    '\n ⌚ ' + inverse(green(bold(' ' + message.toUpperCase() + ' '))) + ' ⌚\n'
   )
 }
 
 function json(object, title = null) {
   let objectFormatted = '\n '
   if (title) {
-    objectFormatted += symbols.info + ' ' + colors.bold(title) + ' \n'
+    objectFormatted += symbols.info + ' ' + bold(title) + ' \n'
   }
   objectFormatted +=
     '\n ' + console.dir(object, { depth: null, colors: true }) + ' \n'
@@ -160,7 +155,7 @@ function json(object, title = null) {
 function unjson(object, title = null) {
   let objectFormatted = '\n '
   if (title) {
-    objectFormatted += symbols.info + ' ' + colors.bold(title) + ' \n'
+    objectFormatted += symbols.info + ' ' + bold(title) + ' \n'
   }
   const objectFlattened = JSON.stringify(object, null, 2)
 
@@ -172,7 +167,7 @@ function unjson(object, title = null) {
       .replace(/[\]]/g, '')
       .replace(/^ {2}/gm, '') +
     ' \n'
-  return console.log(colors.cyan(objectFormatted))
+  return console.log(cyan(objectFormatted))
 }
 
 module.exports = {
@@ -180,5 +175,4 @@ module.exports = {
   watch,
   json,
   unjson,
-  colors,
 }

--- a/src/ops/validation.js
+++ b/src/ops/validation.js
@@ -12,7 +12,7 @@ const e = require.main.require('./src/ops/errors')
 const notify = require.main.require('./src/ops/notifications')
 /* eslint-enable no-unused-vars */
 
-module.exports = function validate (type, selector, opt) {
+module.exports = function validate(type, selector, opt) {
   // If this is an email variable and no email has been set, skip.
   if (selector.includes('config.email') && !config.current.email) {
     process.exit(0)
@@ -39,7 +39,7 @@ module.exports = function validate (type, selector, opt) {
 }
 
 // If value is a string, send it to be validated; if not, iterate over it.
-function checkType (type, value, location, file, opt) {
+function checkType(type, value, location, file, opt) {
   if (typeof value === 'object' && value.constructor === Object) {
     iterate(type, value, location, file, opt)
   } else {
@@ -49,7 +49,7 @@ function checkType (type, value, location, file, opt) {
 
 // Iterate over a value until something that isn't an object or boolean is
 // encountered. Note that numbers are coerced into strings.
-function iterate (type, value, location, file, opt) {
+function iterate(type, value, location, file, opt) {
   for (var k in value) {
     if (typeof value[k] === 'object' && value[k] !== null) {
       iterate(type, value[k], location, file, opt)
@@ -65,7 +65,7 @@ function iterate (type, value, location, file, opt) {
 }
 
 // Process validation of strings and notify on failures.
-function scan (type, value, location, file, opt) {
+function scan(type, value, location, file, opt) {
   if (value !== null && typeof value !== 'undefined') {
     const unquoted = v.trim(value, "'")
     let err
@@ -74,7 +74,7 @@ function scan (type, value, location, file, opt) {
       // ASCII: Strings that are restricted to ASCII characters.
       case 'ascii':
         err = {
-          message: `Non-ASCII characters detected in ${file}:\n   ${location}: ${value}`,
+          message: `Non-ASCII characters detected in ${file}:\n    ${location}: ${value}`,
           type: 'validation',
           subtype: 'ASCII',
         }
@@ -82,7 +82,7 @@ function scan (type, value, location, file, opt) {
       // Size: Must be in pixels.
       case 'size':
         err = {
-          message: `MJML requires all sizes to be in pixels. Check ${file}\n   ${location}: ${value}`,
+          message: `MJML requires all sizes to be in pixels. Check ${file}\n    ${location}: ${value}`,
           type: 'validation',
           subtype: 'Size',
         }
@@ -92,7 +92,7 @@ function scan (type, value, location, file, opt) {
       // oneOf: Only strings provided in the 'opt' array are valid.
       case 'oneOf':
         err = {
-          message: `Invalid setting in ${file}\n   ${location} set to '${value}', but must be one of: ${opt}`,
+          message: `Invalid setting in ${file}\n    ${location} set to '${value}', but must be one of: ${opt}`,
           type: 'validation',
           subtype: 'One-of',
         }
@@ -103,10 +103,10 @@ function scan (type, value, location, file, opt) {
           type: 'validation',
           subtype: 'URL',
           quote: {
-            message: `URL value must be double quoted in ${file}\n   ${location}: ${value}`,
+            message: `URL value must be double quoted in ${file}\n    ${location}: ${value}`,
           },
           url: {
-            message: `Invalid URL in ${file}\n   ${location}: ${unquoted}`,
+            message: `Invalid URL in ${file}\n    ${location}: ${unquoted}`,
           },
         }
         return (
@@ -118,7 +118,7 @@ function scan (type, value, location, file, opt) {
       // Display an error if an unrecognized validation is requested.
       default:
         err = {
-          message: `Validation type not recognized\n   Requested validation type: ${type}`,
+          message: `Validation type not recognized\n    Requested validation type: ${type}`,
         }
         throw e.e(err)
     }

--- a/src/tasks/destroy.js
+++ b/src/tasks/destroy.js
@@ -3,6 +3,7 @@
 /* eslint-disable no-unused-vars */
 const fs = require('fs-extra')
 const path = require('path')
+const symbols = require('log-symbols')
 const prompts = require('prompts')
 
 const isDirEmpty = require.main.require('./src/helpers/isDirEmpty')
@@ -64,9 +65,10 @@ function confirm() {
         message: '',
         onRender(kleur) {
           this.msg = kleur
-            .black()
-            .bgYellow(
-              ' ⚠ This will DESTROY ALL PREMAIL DATA in this directory. Are you sure you want to continue? '
+            .inverse()
+            .yellow()
+            .bold(
+              ` ${symbols.warning} This will DESTROY ALL PREMAIL DATA in this directory. Are you sure you want to continue? `
             )
         },
       },


### PR DESCRIPTION
Fixes #45 

With regret, we say goodbye to brighter green so as to (vastly) reduce deps and speed things up with kleur. 

We are trading two deps (`ansi-colors` and `ansi-colors-prioritized`) for two others (`kleur` and `log-symbols`) but because kleur is already being used with `prompts` (part of `init`/`destroy`) and log-symbols is actually smaller than the comparable part of ansi-colors, the result is overall savings in size.

And kleur is definitely faster than ansi-colors, so even if it was a wash in file size it would be worth it for performance.